### PR TITLE
Fix osx sed bugs

### DIFF
--- a/git-project
+++ b/git-project
@@ -25,6 +25,17 @@ BASE=${PWD##*/}
 # operation mode
 MODE="USAGE"
 
+darwin=false;
+case "`uname`" in
+  Darwin*) darwin=true ;;
+esac
+
+if $darwin; then
+  sedi="/usr/bin/sed -i ''"
+else
+  sedi="sed -i"
+fi
+
 # set MODE
 case $1 in
     init)
@@ -132,7 +143,7 @@ elif [ $MODE == SAVE ] ; then
     echo "Saving repo state:"
     echo $GITPROJ
 
-    sed -i'' -e '/^states:$/,$d' $GITPROJ
+    sedi -e '/^states:$/,$d' $GITPROJ
     echo "states:" >> $GITPROJ
 
     while read -r line || [[ -n "$line" ]]; do


### PR DESCRIPTION
- Use `sed -i '' -e ...` on osx machines (UNAME==Darwin), and
  `sed -i -e ...` on other machines.
- Ensure we use osx sed on osx machines, even if they have gnu sed
  installed.

Resolves: #6, #7