### PR TITLE
Default to not updating past the tagged commit

### DIFF
--- a/git-project
+++ b/git-project
@@ -62,10 +62,14 @@ update = False
 # ------------------------------------------------------------------------
 # parse args
 
+only_these = []
+flags_done = False
 args_iter = 2
 while args_iter < argc:
     arg = argv[args_iter]
-    if arg == '-f' or arg == '--force':
+    if flags_done:
+        only_these.append(arg)
+    elif arg == '-f' or arg == '--force':
         force = True
     elif arg == '-c' or arg == '--commit':
         usecommit = True
@@ -77,6 +81,8 @@ while args_iter < argc:
         update = True
     elif arg == '--autopush':
         autopush = True # for testing purposes only
+    elif arg == '--':
+        flags_done = True
     else:
         usage()
 
@@ -147,7 +153,13 @@ elif MODE == 'save':
             elif char == 'y':
                 break
 
-    for repo, repo_info in subrepo_info.items():
+    if len(only_these) > 0:
+        repos_to_update = only_these
+    else:
+        repos_to_update = subrepos
+
+    for repo in repos_to_update:
+        repo_info = subrepo_info[repo]
         os.chdir(repo)
         branch = subprocess.check_output('git branch | grep "*" | awk \'{ print $2 }\'', shell=True).strip()
         commit = subprocess.check_output('git log | head -n1 | awk \'{ print $2 }\'', shell=True).strip()
@@ -271,14 +283,12 @@ elif MODE == 'load':
                             break
 
                 if push == 'y':
-                    print '-PUSH-'
                     if subprocess.call('git push', shell=True) != 0:
                         print 'You have an un-pushed state and a simple push failed; refusing to orphan your commits'
                         finish(1)
                     checkout = 'y'
 
             if checkout == 'y':
-                print '-CHECKOUT-'
                 subprocess.call('git checkout -B {} {}'.format(branch, commit), shell=True)
                 subprocess.call('git fetch origin --prune', shell=True)
 

--- a/git-project
+++ b/git-project
@@ -5,7 +5,7 @@ CWD=$(pwd)
 # --- Define Functions ---
 finish (){
     cd $CWD
-    exit $1 
+    exit $1
 }
 
 # Switch to root directory and ensure
@@ -19,9 +19,9 @@ if [ ! -s .gitproj ]; then
     finish 0
 fi
 # Location of .gitproj
-GITPROJ=$(pwd)/.gitproj 
+GITPROJ=$(pwd)/.gitproj
 # name of repository
-BASE=${PWD##*/} 
+BASE=${PWD##*/}
 # operation mode
 MODE="USAGE"
 
@@ -103,7 +103,7 @@ if [ $MODE == INIT ]; then
         if [ $? -ne 0 ]; then
             echo "Cloning $repo..."
             git clone $url $repo
-                
+
             if [ $? -ne 0 ]; then
                 echo "Error cloning repo $repo"
                 finish 1
@@ -143,7 +143,7 @@ elif [ $MODE == STATUS ] ; then
     if $columnExists ; then
         echo -e "$output" | column -t
     else
-        echo -e "$output" 
+        echo -e "$output"
     fi
 
     echo ""
@@ -251,9 +251,9 @@ elif [ $MODE == LOAD ]; then
 
         cd $repo;
         if [ $? -ne 0 ]; then
-            if $AUTOCLONE || $FORCE; then 
+            if $AUTOCLONE || $FORCE; then
                 clone=y
-            else 
+            else
                 read -n 1 -p "Unknown sub-repo $repo, do you want to try to clone it? [y/n/q] "  clone </dev/tty;
             fi
             if [ $clone == y ]; then
@@ -302,7 +302,7 @@ elif [ $MODE == LOAD ]; then
         fi
         echo ""
         cd - >> /dev/null;
-    done <<< "$repoStates" 
+    done <<< "$repoStates"
 
 elif [ $MODE == USAGE ]; then
     echo "Usage: git project <init|save|load> [--repos <repos>]"

--- a/git-project
+++ b/git-project
@@ -61,6 +61,7 @@ FORCE=false
 USECOMMIT=false
 AUTOCLONE=false
 AUTOMERGE=false
+UPDATE=false
 
 # set flags
 while [[ $# -ge 1 ]];
@@ -78,6 +79,9 @@ do
             ;;
         -m|--automerge)
             AUTOMERGE=true
+            ;;
+	    -u|--update)
+            UPDATE=true
             ;;
         -r|--repos)
             echo "Repos not yet implemented"
@@ -225,16 +229,18 @@ elif [ $MODE == LOAD ]; then
 
     if [ `git status | grep "behind" | wc -l` -ne 0 ]; then
 
-        if $AUTOMERGE || $FORCE; then 
-            merge=y
-        else 
-            read -n 1 -p "There are new commits in $BASE:$branch. Do you want to merge them in? [y/n/q] " merge < /dev/tty
-        fi
+        if $UPDATE || $AUTOMERGE || $FORCE; then
+            if $AUTOMERGE || $FORCE; then
+                merge=y
+            else
+                read -n 1 -p "There are new commits in $BASE:$branch. Do you want to merge them in? [y/n/q] " merge < /dev/tty
+            fi
 
-        if [ $merge == y ]; then
-            git merge origin/$branch
-        elif [ $merge == q ]; then
-            finish 1
+            if [ $merge == y ]; then
+                git merge origin/$branch
+            elif [ $merge == q ]; then
+                finish 1
+            fi
         fi
     else
         echo "Your branch is up-to-date with 'origin/$branch'."
@@ -279,20 +285,22 @@ elif [ $MODE == LOAD ]; then
         if $USECOMMIT; then
             git checkout $commit
         else
-            git checkout $branch
+            git checkout -B $branch $commit
             git fetch origin --prune
             if [ `git status | grep "behind" | wc -l` -ne 0 ]; then
 
-                if $AUTOMERGE || $FORCE; then 
-                    merge=y
-                else 
-                    read -n 1 -p "There are new commits on $repo:$branch, do you want to merge them in? [y/n/q] "  merge </dev/tty
-                fi
+                if $UPDATE || $AUTOMERGE || $FORCE; then
+                    if $AUTOMERGE || $FORCE; then
+                        merge=y
+                    else
+                        read -n 1 -p "There are new commits on $repo:$branch, do you want to merge them in? [y/n/q] "  merge </dev/tty
+                    fi
 
-                if [ $merge == y ]; then
-                    git merge origin/$branch
-                elif [ $merge == q ]; then
-                    finish 1
+                    if [ $merge == y ]; then
+                        git merge origin/$branch
+                    elif [ $merge == q ]; then
+                        finish 1
+                    fi
                 fi
             fi
         fi

--- a/git-project
+++ b/git-project
@@ -285,6 +285,13 @@ elif [ $MODE == LOAD ]; then
         if $USECOMMIT; then
             git checkout $commit
         else
+            if [ `git status -sb | grep "ahead"` ]; then
+                git push
+                if [ $? != 0 ]; then
+                    echo "You have un-pushed state and a simple push failed; refusing to orphan your commits"
+                    finish 1
+                fi
+            fi
             git checkout -B $branch $commit
             git fetch origin --prune
             if [ `git status | grep "behind" | wc -l` -ne 0 ]; then

--- a/git-project
+++ b/git-project
@@ -1,338 +1,347 @@
-#!/bin/bash
+#!/usr/bin/python
 
-CWD=$(pwd)
+import subprocess
+import os
+import sys
 
-# --- Define Functions ---
-finish (){
-    cd $CWD
-    exit $1
-}
+argv = sys.argv
+argc = len(argv)
 
-# Switch to root directory and ensure
-# .gitproj exists
-root=$(git rev-parse --show-toplevel)
+cwd = os.getcwd()
 
-cd $root
 
-if [ ! -s .gitproj ]; then
-    echo ".gitproj file missing. Refer to the git-project readme"
-    finish 0
-fi
-# Location of .gitproj
-GITPROJ=$(pwd)/.gitproj
-# name of repository
-BASE=${PWD##*/}
-# operation mode
-MODE="USAGE"
+def finish(exitcode=0):
+    os.chdir(cwd)
+    sys.exit(exitcode)
 
-darwin=false;
-case "`uname`" in
-  Darwin*) darwin=true ;;
-esac
 
-if $darwin; then
-  sedi="/usr/bin/sed -i .bak"
-else
-  sedi="sed -i"
-fi
+def usage(exitcode=0):
+    print "Usage: git project <init|save|load> [--repos <repos>]"
+    finish(exitcode)
 
-# set MODE
-case $1 in
-    init)
-        MODE="INIT"
-        ;;
-    save)
-        MODE="SAVE"
-        ;;
-    load)
-        MODE="LOAD"
-        ;;
-    status)
-        MODE="STATUS"
-        ;;
-    *)
-        ;;
-esac
 
-shift
+if argc < 2:
+    usage(1)
 
-# operation styles
-FORCE=false
-USECOMMIT=false
-AUTOCLONE=false
-AUTOMERGE=false
-UPDATE=false
 
-# set flags
-while [[ $# -ge 1 ]];
-do
-    key="$1"
-    case $key in
-        -f|--force)
-            FORCE=true
-            ;;
-        -c|--commit)
-            USECOMMIT=true
-            ;;
-        -a|--autoclone)
-            AUTOCLONE=true
-            ;;
-        -m|--automerge)
-            AUTOMERGE=true
-            ;;
-	    -u|--update)
-            UPDATE=true
-            ;;
-        -r|--repos)
-            echo "Repos not yet implemented"
-            ;;
-        *)
-            ;;
-    esac
-    shift
-done
+root = subprocess.check_output('git rev-parse --show-toplevel', shell=True).strip()
 
-subrepos=`cat $GITPROJ | sed -n -e '/^repos:$/,/^states:$/p' | grep -v ':$'`
+os.chdir(root)
 
-if [ $MODE == INIT ]; then
+if not os.path.isfile('.gitproj'):
+    print '.gitproj file missing. Refer to the git-project readme'
+    finish(1)
 
-    while read -r line || [[ -n "$line" ]]; do
-        repo=`echo $line | awk '{print $1}'`;
-        url=`echo $line | awk '{print $2}'`;
+gitproj_location = os.path.abspath('.gitproj')
 
-        echo "cloning repo..."
-        echo "$line"
+BASE = os.path.dirname(gitproj_location).split(os.sep)[-1]
 
-        cd $repo;
-        if [ $? -ne 0 ]; then
-            echo "Cloning $repo..."
-            git clone $url $repo
+darwin = False
+if subprocess.check_output('uname', shell=True).strip() == 'Darwin':
+    darwin = True
 
-            if [ $? -ne 0 ]; then
-                echo "Error cloning repo $repo"
-                finish 1
-            fi
+if darwin:
+    sedi = '/usr/bin/sed -i .bak'
+else:
+    sedi = 'sed -i'
 
-            echo "$repo" >> .gitignore
-        fi
+MODE = argv[1]
 
-    done <<< "$subrepos"
+if MODE not in ['init', 'save', 'load', 'status']:
+    usage(1)
 
-elif [ $MODE == STATUS ] ; then
 
-    columnExists=false
-    hash column 2>/dev/null
-    if [ $? -eq 0 ] ; then
-        columnExists=true
-    fi
+force = False
+autopush = False
+usecommit = False
+autoclone = False
+automerge = False
+update = False
 
-    output=""
-    while read -r line || [[ -n "$line" ]]; do
-        repo=`echo $line | awk '{print $1}'`;
 
-        cd $repo;
-        if [ $? -ne 0 ]; then
-            output="$output\n$repo >>>>>DOES NOT EXIST. CLONE FIRST<<<<<"
-        else
-            branch=$(git branch | grep "*" | awk '{ print $2 }')
-            commit=$(git log | head -n1 | awk '{print $2}')
-            output="$output\n$repo $branch $commit"
-        fi
-        cd - >> /dev/null
-    done <<< "$subrepos"
+# ------------------------------------------------------------------------
+# parse args
 
-    echo ""
-    echo "-----CURRENT STATE (to be written on 'git project save')-----"
-    echo ""
-    if $columnExists ; then
-        echo -e "$output" | column -t
-    else
-        echo -e "$output"
-    fi
+args_iter = 2
+while args_iter < argc:
+    arg = argv[args_iter]
+    if arg == '-f' or arg == '--force':
+        force = True
+    elif arg == '-c' or arg == '--commit':
+        usecommit = True
+    elif arg == '-a' or arg == '--autoclone':
+        autoclone = True
+    elif arg == '-m' or arg == '--automerge':
+        automerge = True
+    elif arg == '-u' or arg == '--update':
+        update = True
+    elif arg == '--autopush':
+        autopush = True # for testing purposes only
+    else:
+        usage()
 
-    echo ""
+    args_iter += 1
 
-    echo "-----SAVED STATE (currently in .gitproj)-----"
-    echo ""
+# ------------------------------------------------------------------------
+# parse .gitproj
 
-    if $columnExists ; then
-        sed -n -e '/^states:$/,$p' $GITPROJ | grep -v ':$' | column -t
-    else
-        sed -n -e '/^states:$/,$p' $GITPROJ | grep -v ':$'
-    fi
-    echo ""
+with open(gitproj_location) as f:
+    lines = [line.strip() for line in f]
 
-elif [ $MODE == SAVE ] ; then
+subrepos = []
+subrepo_info = {}
+parsing = 0
+for line in lines:
+    if parsing == 0 and line == 'repos:':
+        parsing = 1
+    elif parsing == 1 and line == 'states:':
+        parsing = 2
+    elif parsing == 1:
+        # parse subrepos info
+        info = line.split(' ')
+        subrepo_info[info[0]] = {'remote': info[1]}
+        subrepos.append(info[0])
+    elif parsing == 2:
+        info = line.split(' ')
+        if info[0] not in subrepo_info:
+            print('Error parsing .gitproj. Unknown repo {}'.format(info[0]))
+            finish(1)
+        subrepo_info[info[0]]['branch'] = info[1].strip()
+        subrepo_info[info[0]]['commit'] = info[2].strip()
 
-    if [ `git status | grep "working directory clean" | wc -l` -ne 1 ]; then
-        echo "You have uncommitted changes. Please commit these before proceeding"
-        finish 1
-    fi
+# ------------------------------------------------------------------------
+# init case
 
-    if ! $FORCE && [ -s $GITPROJ ]; then
-        read -n 1 -p "Saved State already exists. Overwrite? [y/n/q]" overwrite < /dev/tty
-        if [ $overwrite != y ]; then
-            finish 1;
-        fi
-    fi
+if MODE == 'init':
 
-    echo "Saving repo state:"
-    echo $GITPROJ
+    for repo in subrepos:
+        repo_info = subrepo_info[repo]
+        url = repo_info['remote']
 
-    $sedi -e '/^states:$/,$d' $GITPROJ
+        print 'cloning repo {} from {}'.format(repo, url)
 
-    if [ -s .gitproj.bak ]; then
-        rm .gitproj.bak
-    fi
+        if not os.path.exists(repo):
+            if subprocess.call('git clone {} {}'.format(url, repo), shell=True) != 0:
+                print 'Error encountered while cloning repo {}'.format(repo)
+                finish(1)
+            subprocess.call('echo "{}" >> .gitignore'.format(repo), shell=True)
+        else:
+            print 'repo already exists!'
 
-    echo "states:" >> $GITPROJ
+elif MODE == 'status':
 
-    while read -r line || [[ -n "$line" ]]; do
-        repo=`echo $line | awk '{print $1}'`
-        cd $repo;
-        branch=`git branch | grep "*" | awk '{ print $2 }'`;
-        commit=`git log | head -n1 | awk '{print $2}'`;
-        echo "    $repo $branch $commit" >> $GITPROJ
-        cd - >> /dev/null;
-    done <<< "$subrepos"
+    print 'TO BE IMPLEMENTED'
 
-#    column -t $GITPROJ
+elif MODE == 'save':
 
-    if [ `git status | grep "working directory clean" | wc -l` -eq 1 ]; then
-        echo "No changes to be saved"
-        exit 0
-    fi
+    if subprocess.call('git status | grep "working directory clean"', shell=True) != 0:
+        print 'You have uncommitted changes. Please commit these before proceeding'
+        finish(1)
+    if not force and os.path.exists(gitproj_location):
+        char = 'a'
+        while True:
+            print 'Saved State already exists. Overwrite? [y/n/q]'
+            char = sys.stdin.read(1)
+            if char == 'q' or char == 'n':
+                finish(0)
+            elif char == 'y':
+                break
 
-    git add $GITPROJ
-    if [ $? -ne 0 ]; then
-        echo "Error"
-        finish 1
-    fi
-    git commit -m "Save Sub-Repository State"
-    if [ $? -ne 0 ]; then
-        echo "Error committing $GITPROJ"
-        finish 1
-    fi
+    for repo, repo_info in subrepo_info.items():
+        os.chdir(repo)
+        branch = subprocess.check_output('git branch | grep "*" | awk \'{ print $2 }\'', shell=True).strip()
+        commit = subprocess.check_output('git log | head -n1 | awk \'{ print $2 }\'', shell=True).strip()
 
-elif [ $MODE == LOAD ]; then
+        repo_info['branch'] = branch
+        repo_info['commit'] = commit
 
-    if [ ! -s $GITPROJ ]; then
-        echo "No Saved State.";
-        exit -1;
-    fi
+        os.chdir(root)
 
-    echo "***$BASE***"
+    with open(gitproj_location, 'w') as f:
+        # iterate through subrepos (to ensure we preserve order)
+        f.write('repos:\n')
+        for repo in subrepos:
+            f.write('\t{} {}\n'.format(repo, subrepo_info[repo]['remote']))
 
-    branch=`git branch | grep "*" | awk '{print $2}'`;
+        f.write('states:\n')
+        for repo in subrepos:
+            f.write('\t{} {} {}\n'.format(repo, subrepo_info[repo]['branch'], subrepo_info[repo]['commit']))
 
-    git fetch origin --prune
+    if subprocess.call('git status | grep "working directory clean"', shell=True) == 0:
+        print 'No changes to be saved'
+        finish(0)
 
-    if [ `git status | grep "behind" | wc -l` -ne 0 ]; then
+    if subprocess.call('git add {}'.format(gitproj_location), shell=True) != 0:
+        print 'Error'
+        finish(1)
 
-        if $UPDATE || $AUTOMERGE || $FORCE; then
-            if $AUTOMERGE || $FORCE; then
-                merge=y
-            else
-                read -n 1 -p "There are new commits in $BASE:$branch. Do you want to merge them in? [y/n/q] " merge < /dev/tty
-            fi
+    if subprocess.call('git commit -m "Save Sub-Repository State"', shell=True) != 0:
+        print 'Error committing .gitproj'
+        finish(1)
 
-            if [ $merge == y ]; then
-                git merge origin/$branch
-            elif [ $merge == q ]; then
-                finish 1
-            fi
-        fi
-    else
-        echo "Your branch is up-to-date with 'origin/$branch'."
-    fi
+elif MODE == 'load':
 
-    echo ""
+    if not os.path.exists(gitproj_location):
+        print 'No Saved State to load'
+        finish(1)
 
-    repoStates=`sed -n -e '/^states:$/,$p' $GITPROJ | grep -v ':$'`
+    print '***{}***'.format(BASE)
 
-    while IFS='' read -r line || [[ -n "$line" ]]; do
-        repo=`echo $line | awk '{print $1}'`;
-        branch=`echo $line | awk '{print $2}'`;
-        commit=`echo $line | awk '{print $3}'`;
+    branch = subprocess.check_output('git branch | grep "*" | awk \'{print $2}\'', shell=True).strip()
 
-        cd $repo;
-        if [ $? -ne 0 ]; then
-            if $AUTOCLONE || $FORCE; then
-                clone=y
-            else
-                read -n 1 -p "Unknown sub-repo $repo, do you want to try to clone it? [y/n/q] "  clone </dev/tty;
-            fi
-            if [ $clone == y ]; then
-                repoUrl=$(echo "$subrepos" | grep "\s$repo\s" | awk '{print $2}')
-                echo "looking for $repo in "
-                echo "$subrepos"
-                echo "found $repoUrl"
-                git clone $repoUrl $repo -b $branch
-                if [ $? -ne 0 ]; then
-                    echo "Error cloning repo $sub"
-                    finish 1
-                fi
-            elif [ $clone == q ]; then
-                finish 1
-            else
+    subprocess.call('git fetch origin --prune', shell=True)
+
+    # if we are behind...
+    if subprocess.call('git status | grep "behind"', shell=True) == 0:
+        if update or automerge or force:
+            if automerge or force:
+                merge = 'y'
+            else:
+                while True:
+                    print 'There are new commits in {}:{}. Do you want to merge them in? [y/n/q] '.format(BASE, branch)
+                    merge = sys.stdin.read(1)
+                    if merge == 'q':
+                        finish(0)
+                    elif merge == 'y' or merge == 'n':
+                        break
+
+            if merge == 'y':
+                subprocess.call('git merge origin/{}'.format(branch), shell=True)
+    else:
+        print 'Your branch is up to date with origin/{}'.format(branch)
+
+    print
+
+    for repo in subrepos:
+
+        repo_info = subrepo_info[repo]
+        branch = repo_info['branch']
+        commit = repo_info['commit']
+
+        # clone repo if it doesn't exist
+        try:
+            os.chdir(repo)
+        except OSError:
+            if autoclone or force:
+                clone = 'y'
+            else:
+                while True:
+                    print 'Unknown sub-repo {}, do you want to try to clone it? [y/n/q] '.format(repo)
+                    clone = sys.stdin.read(1)
+                    if clone == 'q':
+                        finish(0)
+                    elif clone == 'y' or clone == 'n':
+                        break
+
+            if clone == 'y':
+                if repo not in subrepo_info:
+                    print 'Error: could not find url for repo {}'.format(repo)
+                    finish(1)
+                url = subrepo_info[repo]['remote']
+                branch = subrepo_info[repo]['branch']
+
+                print 'Attempting to clone {} from {}'.format(repo, url)
+                if subprocess.call('git clone {} {} -b {}'.format(url, repo, branch), shell=True) != 0:
+                    print 'Error cloning repo {}'.format(repo)
+                    finish(1)
+
+                os.chdir(repo)
+            elif clone == 'n':
                 continue
-            fi
 
-            cd $repo;
-        fi
+        print '***{}***'.format(repo)
 
-        echo "***$repo***"
-        if $USECOMMIT; then
-            git checkout $commit
-        else
-            checkout=y
-            if [ `git status -sb | grep "ahead" | wc -l` -ne 0 ]; then
-                checkout=n
-                read -n 1 -p "You have un-pushed work in $repo. Do you want to push to the default remote? [y/n/q] " push < /dev/tty;
+        if usecommit:
+            subprocess.call('git checkout {}'.format(commit), shell=True)
+        else:
+            checkout = 'y'
+            # if ahead
+            if subprocess.call('git status -sb | grep "ahead"', shell=True) == 0:
+                checkout = 'n'
+                push = 'n'
+                if autopush:
+                    push = 'y'
+                else:
+                    while True:
+                        sys.stdout.write('You have un-pushed work in {}. Attempt to push to the default remote? [y/n/q]'.format(repo))
+                        push = sys.stdin.read(1)
+                        if push == 'q':
+                            finish(0)
+                        elif push == 'y' or push == 'n':
+                            break
 
-                if [ $push == y ]; then
-                    git push
-                    checkout=y
-                elif [ $push == q ]; then
-                    finish 1
-                fi
-                if [ $? != 0 ]; then
-                    echo "You have un-pushed state and a simple push failed; refusing to orphan your commits"
-                    finish 1
-                fi
-            fi
-            if [ $checkout == y ]; then
-                git checkout -B $branch $commit
-                git fetch origin --prune
-                if [ `git status | grep "behind" | wc -l` -ne 0 ]; then
+                if push == 'y':
+                    print '-PUSH-'
+                    if subprocess.call('git push', shell=True) != 0:
+                        print 'You have an un-pushed state and a simple push failed; refusing to orphan your commits'
+                        finish(1)
+                    checkout = 'y'
 
-                    if $UPDATE || $AUTOMERGE || $FORCE; then
-                        if $AUTOMERGE || $FORCE; then
-                            merge=y
-                        else
-                            read -n 1 -p "There are new commits on $repo:$branch, do you want to merge them in? [y/n/q] "  merge </dev/tty
-                        fi
+            if checkout == 'y':
+                print '-CHECKOUT-'
+                subprocess.call('git checkout -B {} {}'.format(branch, commit), shell=True)
+                subprocess.call('git fetch origin --prune', shell=True)
 
-                        if [ $merge == y ]; then
-                            git merge origin/$branch
-                        elif [ $merge == q ]; then
-                            finish 1
-                        fi
-                    fi
-                fi
-            fi
-        fi
-        if [ $? -ne 0 ]; then
-            echo "Encountered an error switching branches. Please fix and re-try"
-            finish 1;
-        fi
-        echo ""
-        cd - >> /dev/null;
-    done <<< "$repoStates"
+                if subprocess.call('git status | grep "behind"', shell=True) == 0:
+                    if update or automerge or force:
+                        if automerge or force:
+                            merge = 'y'
+                        else:
+                            while True:
+                                print 'There are new commits on {}:{}, merge? [y/n/q] '.format(repo, branch)
+                                merge = sys.stdin.read(1)
+                                if merge == 'q':
+                                    finish(0)
+                                elif merge == 'y' or merge == 'n':
+                                    break
+                        if merge == 'y':
+                            subprocess.call('git merge origin/{}'.format(branch), shell=True)
 
-elif [ $MODE == USAGE ]; then
-    echo "Usage: git project <init|save|load> [--repos <repos>]"
-    finish 1
-fi
+        os.chdir(root)
 
-finish 0
+
+finish(0)
+
+# --- old code for git project status ---
+
+#     columnExists=false
+#     hash column 2>/dev/null
+#     if [ $? -eq 0 ] ; then
+#         columnExists=true
+#     fi
+#
+#     output=""
+#     while read -r line || [[ -n "$line" ]]; do
+#         repo=`echo $line | awk '{print $1}'`;
+#
+#         cd $repo;
+#         if [ $? -ne 0 ]; then
+#             output="$output\n$repo >>>>>DOES NOT EXIST. CLONE FIRST<<<<<"
+#         else
+#             branch=$(git branch | grep "*" | awk '{ print $2 }')
+#             commit=$(git log | head -n1 | awk '{print $2}')
+#             output="$output\n$repo $branch $commit"
+#         fi
+#         cd - >> /dev/null
+#     done <<< "$subrepos"
+#
+#     echo ""
+#     echo "-----CURRENT STATE (to be written on 'git project save')-----"
+#     echo ""
+#     if $columnExists ; then
+#         echo -e "$output" | column -t
+#     else
+#         echo -e "$output"
+#     fi
+#
+#     echo ""
+#
+#     echo "-----SAVED STATE (currently in .gitproj)-----"
+#     echo ""
+#
+#     if $columnExists ; then
+#         sed -n -e '/^states:$/,$p' $GITPROJ | grep -v ':$' | column -t
+#     else
+#         sed -n -e '/^states:$/,$p' $GITPROJ | grep -v ':$'
+#     fi
+#     echo ""

--- a/git-project
+++ b/git-project
@@ -285,28 +285,38 @@ elif [ $MODE == LOAD ]; then
         if $USECOMMIT; then
             git checkout $commit
         else
-            if [ `git status -sb | grep "ahead"` ]; then
-                git push
+            checkout=n
+            if [ `git status -sb | grep "ahead" | wc -l` -ne 0 ]; then
+                read -n 1 -p "You have un-pushed work in $repo. Do you want to push to the default remote? [y/n/q] " push < /dev/tty;
+
+                if [ $push == y ]; then
+                    git push
+                    checkout=y
+                elif [ $push == q ]; then
+                    finish 1
+                fi
                 if [ $? != 0 ]; then
                     echo "You have un-pushed state and a simple push failed; refusing to orphan your commits"
                     finish 1
                 fi
             fi
-            git checkout -B $branch $commit
-            git fetch origin --prune
-            if [ `git status | grep "behind" | wc -l` -ne 0 ]; then
+            if [ $checkout == y ]; then
+                git checkout -B $branch $commit
+                git fetch origin --prune
+                if [ `git status | grep "behind" | wc -l` -ne 0 ]; then
 
-                if $UPDATE || $AUTOMERGE || $FORCE; then
-                    if $AUTOMERGE || $FORCE; then
-                        merge=y
-                    else
-                        read -n 1 -p "There are new commits on $repo:$branch, do you want to merge them in? [y/n/q] "  merge </dev/tty
-                    fi
+                    if $UPDATE || $AUTOMERGE || $FORCE; then
+                        if $AUTOMERGE || $FORCE; then
+                            merge=y
+                        else
+                            read -n 1 -p "There are new commits on $repo:$branch, do you want to merge them in? [y/n/q] "  merge </dev/tty
+                        fi
 
-                    if [ $merge == y ]; then
-                        git merge origin/$branch
-                    elif [ $merge == q ]; then
-                        finish 1
+                        if [ $merge == y ]; then
+                            git merge origin/$branch
+                        elif [ $merge == q ]; then
+                            finish 1
+                        fi
                     fi
                 fi
             fi

--- a/git-project
+++ b/git-project
@@ -285,8 +285,9 @@ elif [ $MODE == LOAD ]; then
         if $USECOMMIT; then
             git checkout $commit
         else
-            checkout=n
+            checkout=y
             if [ `git status -sb | grep "ahead" | wc -l` -ne 0 ]; then
+                checkout=n
                 read -n 1 -p "You have un-pushed work in $repo. Do you want to push to the default remote? [y/n/q] " push < /dev/tty;
 
                 if [ $push == y ]; then

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -12,7 +12,7 @@ class TestInstall(unittest.TestCase):
         subprocess.call('rm .gitproj 2>> /dev/null; exit 0;', stderr=subprocess.STDOUT, shell=True)
 
         try:
-            output = subprocess.check_output('git project', shell=True)
+            output = subprocess.check_output('git project init', shell=True)
         except subprocess.CalledProcessError as err:
             self.assertEqual('.gitproj file missing. Refer to the git-project readme\n', err.output)
             self.assertEqual(1, err.returncode)

--- a/test/test_noOverwrite.py
+++ b/test/test_noOverwrite.py
@@ -1,0 +1,69 @@
+#!bin/env python
+
+import subprocess
+import os.path
+import unittest, re
+
+
+class TestNoOverwrite(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+
+        # clean up, just in case
+        subprocess.call('rm -rf remote local 2>> /dev/null', shell=True)
+
+        # Create "local" and "remote" repositories
+        subprocess.call('mkdir remote; mkdir local', shell=True)
+        subprocess.call('cd remote; mkdir parent; cd parent; git init --bare', shell=True)
+        subprocess.call('cd remote; mkdir child; cd child; git init --bare', shell=True)
+
+        subprocess.call('cd local;  git clone ../remote/parent', shell=True)
+        subprocess.call('cd local;  git clone ../remote/child', shell=True)
+
+        # initialize the git-project for local/parent
+        subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tchild ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
+
+        # clone the child repo into the parent through git project init
+        subprocess.call('cd local/parent;  git project init', shell=True)
+        subprocess.call('cd local/parent;  git add .gitignore; git commit -m ".gitignore"; git push', shell=True)
+
+    def test_safety(self):
+        # check to ensure the child repo was cloned
+        output = subprocess.check_output('cd local/parent; ls | grep child | awk \'{print $1}\'', shell=True)
+        self.assertEqual(output, 'child\n')
+
+        # ensure the child's remote is correct
+        output = subprocess.check_output('cd local/parent/child; git remote show origin | grep Fetch | grep remote/child | wc -l', shell=True)
+        self.assertEqual(output.strip().replace('\n',''), '1')
+
+        # add a commit and SAVE it into the git-project (simulate working inside the parent-repo's copy of child)
+        subprocess.call('cd local/parent/child; echo "Asdf" > test.txt; git add test.txt; git commit -m "Initial Commit"; git push', shell=True)
+        subprocess.call('cd local/parent; git project save -f', shell=True)
+
+        # add a second commit but DO NOT PUSH IT
+        subprocess.call('cd local/parent/child; echo "Asdf2" > test2.txt; git add test2.txt; git commit -m "Second Commit";', shell=True)
+
+        # tell git project load to update
+        subprocess.call('cd local/parent; expect -c "spawn git project load; set timeout 3; expect -re \".*un-pushed.*\"; send \"y\"; expect eof"', shell=True)
+
+        # ensure we are now behind
+        output = subprocess.check_output('cd local/parent/child; git status | grep "behind" | wc -l', shell=True)
+        self.assertEqual(output.strip().replace('\n',''), '1')
+
+        subprocess.call('cd local/parent; git project load --update -f', shell=True)
+
+        # ensure git project load --update DOES update the child repo, as per previous functionality
+        output = subprocess.check_output('cd local/parent/child; git status | grep "behind" | wc -l', shell=True)
+        self.assertEqual(output.strip().replace('\n',''), '0')
+
+
+    @classmethod
+    def tearDownClass(self):
+
+        subprocess.call('rm -rf remote local', shell=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_noOverwrite.py
+++ b/test/test_noOverwrite.py
@@ -46,8 +46,15 @@ class TestNoOverwrite(unittest.TestCase):
         # add a second commit but DO NOT PUSH IT
         subprocess.call('cd local/parent/child; echo "Asdf2" > test2.txt; git add test2.txt; git commit -m "Second Commit";', shell=True)
 
-        # tell git project load to update
-        subprocess.call('cd local/parent; expect -c "spawn git project load; set timeout 10; expect -re \".*un-pushed.*\"; send \"y\"; expect eof"', shell=True)
+
+        subprocess.call('cd local/parent; git project load --autopush', shell=True)
+
+#       TODO: MAKE THIS WORK!!!
+#        expect='cd local/parent; expect -c "spawn git project load; set timeout 3; expect -re \".*un-pushed.*\"; send \"y\\n\"; expect eof"'
+#        child = pexpect.spawn('cd local/parent && git project load')
+#        child.expect('You.*')
+#        child.sendline('y\r')
+#        subprocess.call(expect, shell=True)
 
         # ensure we are now behind
         output = subprocess.check_output('cd local/parent/child; git status | grep "behind" | wc -l', shell=True)

--- a/test/test_noOverwrite.py
+++ b/test/test_noOverwrite.py
@@ -30,7 +30,7 @@ class TestNoOverwrite(unittest.TestCase):
         subprocess.call('cd local/parent;  git project init', shell=True)
         subprocess.call('cd local/parent;  git add .gitignore; git commit -m ".gitignore"; git push', shell=True)
 
-    def test_safety(self):
+    def test_noOverwrite(self):
         # check to ensure the child repo was cloned
         output = subprocess.check_output('cd local/parent; ls | grep child | awk \'{print $1}\'', shell=True)
         self.assertEqual(output, 'child\n')
@@ -47,7 +47,7 @@ class TestNoOverwrite(unittest.TestCase):
         subprocess.call('cd local/parent/child; echo "Asdf2" > test2.txt; git add test2.txt; git commit -m "Second Commit";', shell=True)
 
         # tell git project load to update
-        subprocess.call('cd local/parent; expect -c "spawn git project load; set timeout 3; expect -re \".*un-pushed.*\"; send \"y\"; expect eof"', shell=True)
+        subprocess.call('cd local/parent; expect -c "spawn git project load; set timeout 10; expect -re \".*un-pushed.*\"; send \"y\"; expect eof"', shell=True)
 
         # ensure we are now behind
         output = subprocess.check_output('cd local/parent/child; git status | grep "behind" | wc -l', shell=True)

--- a/test/test_safety.py
+++ b/test/test_safety.py
@@ -58,7 +58,7 @@ class TestSafety(unittest.TestCase):
 
         subprocess.call('cd local/parent; git project load --update -f', shell=True)
 
-        # ensure git project load DID NOT update the child repo
+        # ensure git project load --update DOES update the child repo, as per previous functionality
         output = subprocess.check_output('cd local/parent/child; git status | grep "behind" | wc -l', shell=True)
         self.assertEqual(output.strip().replace('\n',''), '0')
 

--- a/test/test_safety.py
+++ b/test/test_safety.py
@@ -56,6 +56,12 @@ class TestSafety(unittest.TestCase):
         output = subprocess.check_output('cd local/parent/child; git status | grep "behind" | wc -l', shell=True)
         self.assertEqual(output.strip().replace('\n',''), '1')
 
+        subprocess.call('cd local/parent; git project load --update -f', shell=True)
+
+        # ensure git project load DID NOT update the child repo
+        output = subprocess.check_output('cd local/parent/child; git status | grep "behind" | wc -l', shell=True)
+        self.assertEqual(output.strip().replace('\n',''), '0')
+
 
     @classmethod
     def tearDownClass(self):

--- a/test/test_safety.py
+++ b/test/test_safety.py
@@ -1,0 +1,66 @@
+#!bin/env python
+
+import subprocess
+import os.path
+import unittest, re
+
+
+class TestSafety(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+
+        # clean up, just in case
+        subprocess.call('rm -rf remote local 2>> /dev/null', shell=True)
+
+        # Create "local" and "remote" repositories
+        subprocess.call('mkdir remote; mkdir local', shell=True)
+        subprocess.call('cd remote; mkdir parent; cd parent; git init --bare', shell=True)
+        subprocess.call('cd remote; mkdir child; cd child; git init --bare', shell=True)
+
+        subprocess.call('cd local;  git clone ../remote/parent', shell=True)
+        subprocess.call('cd local;  git clone ../remote/child', shell=True)
+
+        # initialize the git-project for local/parent
+        subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tchild ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
+
+        # clone the child repo into the parent through git project init
+        subprocess.call('cd local/parent;  git project init', shell=True)
+        subprocess.call('cd local/parent;  git add .gitignore; git commit -m ".gitignore"; git push', shell=True)
+
+    def test_safety(self):
+        # check to ensure the child repo was cloned
+        output = subprocess.check_output('cd local/parent; ls | grep child | awk \'{print $1}\'', shell=True)
+        self.assertEqual(output, 'child\n')
+
+        # ensure the child's remote is correct
+        output = subprocess.check_output('cd local/parent/child; git remote show origin | grep Fetch | grep remote/child | wc -l', shell=True)
+        self.assertEqual(output.strip().replace('\n',''), '1')
+
+        # add a commit and SAVE it into the git-project (simulate working inside the parent-repo's copy of child)
+        subprocess.call('cd local/parent/child; echo "Asdf" > test.txt; git add test.txt; git commit -m "Initial Commit"; git push', shell=True)
+        subprocess.call('cd local/parent; git project save -f', shell=True)
+
+        # ensure git project load DID update the child repo
+        output = subprocess.check_output('cd local/parent/child; git status | grep "behind" | wc -l', shell=True)
+        self.assertEqual(output.strip().replace('\n',''), '0')
+
+        # create a commit we DO NOT WANT to include in the git-project
+        subprocess.call('cd local/child; git pull', shell=True)
+        subprocess.call('cd local/child; echo "asdf2" > test2.txt; git add test2.txt; git commit -m "Second Commit"; git push', shell=True)
+        subprocess.call('cd local/parent; git project load', shell=True)
+
+        # ensure git project load DID NOT update the child repo
+        output = subprocess.check_output('cd local/parent/child; git status | grep "behind" | wc -l', shell=True)
+        self.assertEqual(output.strip().replace('\n',''), '1')
+
+
+    @classmethod
+    def tearDownClass(self):
+
+        subprocess.call('rm -rf remote local', shell=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_saveSingle.py
+++ b/test/test_saveSingle.py
@@ -1,0 +1,82 @@
+#!bin/env python
+
+import subprocess
+import os.path
+import unittest
+
+
+class TestSaveLoad(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+
+        subprocess.call('rm -rf remote local 2>> /dev/null', shell=True)
+
+        subprocess.call('mkdir remote; mkdir local', shell=True)
+        subprocess.call('cd remote; mkdir parent; cd parent; git init --bare', shell=True)
+        subprocess.call('cd remote; mkdir child; cd child; git init --bare', shell=True)
+        subprocess.call('cd remote; mkdir child2; cd child2; git init --bare', shell=True)
+
+        subprocess.call('cd local;  git clone ../remote/parent', shell=True)
+        subprocess.call('cd local;  git clone ../remote/child', shell=True)
+        subprocess.call('cd local;  git clone ../remote/child2', shell=True)
+
+        subprocess.call('cd local/parent;  echo "repos:" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tchild ../../remote/child" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  echo "\tchild2 ../../remote/child2" >> .gitproj', shell=True)
+        subprocess.call('cd local/parent;  git add .gitproj; git commit -m "Initial Commit"; git push -u origin master', shell=True)
+
+
+    def test_single(self):
+
+        subprocess.call('cd local/parent;  git project init', shell=True)
+        subprocess.call('cd local/parent;  git add .gitignore; git commit -m ".gitignore"; git push', shell=True)
+
+        output = subprocess.check_output('cd local/parent; ls | grep child | awk \'{print $1}\'', shell=True)
+        self.assertEqual(output, 'child\nchild2\n')
+
+        output = subprocess.check_output('cd local/parent/child; git remote show origin | grep Fetch | grep remote/child | wc -l', shell=True)
+
+        self.assertEqual(output.strip().replace('\n',''), '1')
+
+        output = subprocess.check_output('cd local/parent/child2; git remote show origin | grep Fetch | grep remote/child2 | wc -l', shell=True)
+
+        self.assertEqual(output.strip().replace('\n',''), '1')
+
+
+        subprocess.call('cd local/parent/child; echo "Asdf" > test.txt; git add test.txt; git commit -m "Initial Commit"; git push', shell=True)
+        subprocess.call('cd local/parent/child2; echo "Asdf" > test.txt; git add test.txt; git commit -m "Initial Commit"; git push', shell=True)
+
+
+        subprocess.call('cd local/parent; git project save -f', shell=True)
+
+
+        self.assertTrue(os.path.isfile('local/parent/.gitproj'))
+
+        output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
+
+        self.assertEqual(output, 'child master\nchild2 master\n')
+
+        subprocess.call('cd local/parent; git checkout -b dev; cd child; git checkout -b dev; cd ../child2; git checkout -b feature', shell=True)
+
+        # tests saving a single repo
+        subprocess.call('cd local/parent; git project save -f -- child', shell=True)
+
+
+        output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
+        self.assertEqual(output, 'child dev\nchild2 master\n')
+
+        subprocess.call('cd local/parent; git project save -f -- child2', shell=True)
+
+        output = subprocess.check_output('cd local/parent; cat .gitproj | tail -n2 | awk \'{print $1, $2}\'', shell=True)
+        self.assertEqual(output, 'child dev\nchild2 feature\n')
+
+
+
+    @classmethod
+    def tearDownClass(self):
+
+        subprocess.call('rm -rf remote local', shell=True)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Running `git project load` now results in all repositories on the correct branch, but with their `HEAD` set to the specified commit in the `.gitproj` file. I.e., behaviour somewhere between the previous behaviour (update everything) and the `--commit` behaviour (specific commit, detached `HEAD`).

A new option `-u|--update` restores the previous behaviour.