### PR TITLE
Hide printout of permissions fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo
 
 install:
-	@if touch $(SYSPATH)/$(EXE); then \
+	@if touch $(SYSPATH)/$(EXE) 2>/dev/null; then \
 		cp $(EXE) $(SYSPATH)/; \
 		chmod +x $(SYSPATH)/$(EXE); \
 	else \


### PR DESCRIPTION
Hides the error message that occurs if we can't install system-wide.