### PR TITLE
Find closest .gitproj from parent dir

### DIFF
--- a/git-project
+++ b/git-project
@@ -28,10 +28,10 @@ root = subprocess.check_output('git rev-parse --show-toplevel', shell=True).stri
 
 # use the cwd .gitproj if exists
 if os.path.exists(cwd+'/.gitproj'):
-    print 'Found .gitproj file in current working dir {}', cwd
+    print 'Found .gitproj file in the current working dir: ', cwd
     root = cwd
 else:
-    print 'Recursively looking for .gitproj from cwd: ', cwd
+    print 'Look for .gitproj from parent directory: ', cwd
     cwd_tmp = cwd;
     last_slash = cwd_tmp.rfind('/');
     while (last_slash != -1):

--- a/git-project
+++ b/git-project
@@ -26,28 +26,49 @@ if argc < 2:
 
 root = subprocess.check_output('git rev-parse --show-toplevel', shell=True).strip()
 
-# use the cwd .gitproj if exists
-if os.path.exists(cwd+'/.gitproj'):
-    print 'Found .gitproj file in the current working dir: ', cwd
-    root = cwd
-else:
-    print 'Look for .gitproj from parent directory: ', cwd
-    cwd_tmp = cwd;
-    last_slash = cwd_tmp.rfind('/');
-    while (last_slash != -1):
-        cwd_tmp = cwd_tmp[:last_slash]
-        gitproj_tmpdir = cwd_tmp + '/.gitproj'
-        if os.path.isfile(gitproj_tmpdir):
-            root = cwd_tmp
-            print 'Found gitproj at ', gitproj_tmpdir
-            break
-        last_slash = cwd_tmp.rfind('/')
-
 os.chdir(root)
 
 if not os.path.isfile('.gitproj'):
     print '.gitproj file missing. Refer to the git-project readme'
     finish(1)
+
+# use the cwd .gitproj if exists
+if os.path.exists(cwd+'/.gitproj'):
+    # if there is a gitproj at cwd use it
+    root = cwd
+    os.chdir(root)
+else:
+    # look for .gitproj in the parent dir, ask for comfirmation if found
+    cwd_tmp = cwd
+    last_slash = cwd_tmp.rfind('/')
+    while (last_slash != -1):
+        cwd_tmp = cwd_tmp[:last_slash]
+        gitproj_tmpdir = cwd_tmp + '/.gitproj'
+        if cwd_tmp.lower() == root.lower():
+            print('Hit the root of the project. Uses project root .gitproj file. Halt.')
+            break
+        if os.path.isfile(gitproj_tmpdir):
+            load_comfirm = raw_input('Found gitproj at ' + gitproj_tmpdir +
+                                      '\nAre you sure you want to use it(y/n)?')
+            found_gitproj = False
+            # make sure user gives either y/n
+            while ((load_comfirm != 'y' or load_comfirm != 'n') and not found_gitproj):
+                if load_comfirm.lower() == 'y':
+                    root = cwd_tmp
+                    os.chdir(root)
+                    found_gitproj = True
+                    break
+                elif load_comfirm.lower() == 'n':
+                    print 'continue searching'
+                    break
+                else:
+                    load_comfirm = raw_input(' invalid input ' + load_comfirm +
+                        '\n Are you sure you want to use ' + gitproj_tmpdir
+                        + '(y/n)?')
+            # break while loop after found gitproj
+            if found_gitproj:
+                break
+        last_slash = cwd_tmp.rfind('/')
 
 gitproj_location = os.path.abspath('.gitproj')
 

--- a/git-project
+++ b/git-project
@@ -25,7 +25,7 @@ def flag_dec(func):
             if PROMPT_ENABLED:
                 return func(*args, **kwargs)
             else:
-                return 'n'
+                return ''  # use empty string to indicate default
         else:
             return None
     return wrapfunc_and_call
@@ -74,7 +74,7 @@ else:
         if cwd_tmp.lower() == root.lower():
             print(
                 'Hit the root of the project. '
-                'Uses project root .gitproj file.')
+                '\nUses project root .gitproj file: ', cwd_tmp)
             break
         if os.path.isfile(gitproj_tmpdir):
             load_confirm = prompt(
@@ -83,13 +83,12 @@ else:
                 )
             found_gitproj = False
             # make sure user gives either y/n
-            while (
-                load_confirm != 'y' or load_confirm != 'n'
-                ) \
-                    and not found_gitproj:
-                if load_confirm.lower() == 'y':
+            while not found_gitproj:
+                if load_confirm.lower() == 'y' or load_confirm == '':
                     root = cwd_tmp
                     os.chdir(root)
+                    print 'using .gitproj found at: ' \
+                        '\n\t{}'.format(gitproj_tmpdir)
                     found_gitproj = True
                     break
                 elif load_confirm.lower() == 'n':

--- a/git-project
+++ b/git-project
@@ -26,6 +26,11 @@ if argc < 2:
 
 root = subprocess.check_output('git rev-parse --show-toplevel', shell=True).strip()
 
+# use the cwd .gitproj if exists
+if os.path.exists(cwd+'/.gitproj'):
+    print('Found .gitproj file in current working dir {}', cwd)
+    root = cwd
+
 os.chdir(root)
 
 if not os.path.isfile('.gitproj'):

--- a/git-project
+++ b/git-project
@@ -65,7 +65,7 @@ if os.path.exists(cwd+'/.gitproj'):
     root = cwd
     os.chdir(root)
 else:
-    # look for .gitproj in the parent dir, ask for comfirmation if found
+    # look for .gitproj in the parent dir, ask for confirmation if found
     cwd_tmp = cwd
     last_slash = cwd_tmp.rfind('/')
     while (last_slash != -1):
@@ -77,27 +77,27 @@ else:
                 'Uses project root .gitproj file.')
             break
         if os.path.isfile(gitproj_tmpdir):
-            load_comfirm = prompt(
+            load_confirm = prompt(
                 'Found gitproj at ' + gitproj_tmpdir +
                 '\nAre you sure you want to use it(y/n)?'
                 )
             found_gitproj = False
             # make sure user gives either y/n
             while (
-                load_comfirm != 'y' or load_comfirm != 'n'
+                load_confirm != 'y' or load_confirm != 'n'
                 ) \
                     and not found_gitproj:
-                if load_comfirm.lower() == 'y':
+                if load_confirm.lower() == 'y':
                     root = cwd_tmp
                     os.chdir(root)
                     found_gitproj = True
                     break
-                elif load_comfirm.lower() == 'n':
+                elif load_confirm.lower() == 'n':
                     print 'continue searching'
                     break
                 else:
-                    load_comfirm = prompt(
-                        ' invalid input ' + load_comfirm +
+                    load_confirm = prompt(
+                        ' invalid input ' + load_confirm +
                         '\n Are you sure you want to use ' + gitproj_tmpdir
                         + '(y/n)?')
             # break while loop after found gitproj

--- a/git-project
+++ b/git-project
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-import fnmatch
 import subprocess
 import os
 import sys
@@ -32,7 +31,7 @@ if os.path.exists(cwd+'/.gitproj'):
     print 'Found .gitproj file in current working dir {}', cwd
     root = cwd
 else:
-    print 'Recursively looking for .gitproj from root: ', cwd
+    print 'Recursively looking for .gitproj from cwd: ', cwd
     cwd_tmp = cwd;
     last_slash = cwd_tmp.rfind('/');
     while (last_slash != -1):

--- a/git-project
+++ b/git-project
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import fnmatch
 import subprocess
 import os
 import sys
@@ -28,8 +29,20 @@ root = subprocess.check_output('git rev-parse --show-toplevel', shell=True).stri
 
 # use the cwd .gitproj if exists
 if os.path.exists(cwd+'/.gitproj'):
-    print('Found .gitproj file in current working dir {}', cwd)
+    print 'Found .gitproj file in current working dir {}', cwd
     root = cwd
+else:
+    print 'Recursively looking for .gitproj from root: ', cwd
+    cwd_tmp = cwd;
+    last_slash = cwd_tmp.rfind('/');
+    while (last_slash != -1):
+        cwd_tmp = cwd_tmp[:last_slash]
+        gitproj_tmpdir = cwd_tmp + '/.gitproj'
+        if os.path.isfile(gitproj_tmpdir):
+            root = cwd_tmp
+            print 'Found gitproj at ', gitproj_tmpdir
+            break
+        last_slash = cwd_tmp.rfind('/')
 
 os.chdir(root)
 

--- a/git-project
+++ b/git-project
@@ -9,6 +9,32 @@ argc = len(argv)
 
 cwd = os.getcwd()
 
+FLAGS = argv[2:]
+PROMPT_ENABLED = True if '--prompt' in FLAGS else False
+
+
+def flag_dec(func):
+    """flags to check function call
+
+    :func: function to be executed based on flag
+    :returns: result of the function call or handles when flag is disabled
+
+    """
+    def wrapfunc_and_call(*args, **kwargs):
+        if func.__name__ == 'prompt':
+            if PROMPT_ENABLED:
+                return func(*args, **kwargs)
+            else:
+                return 'n'
+        else:
+            return None
+    return wrapfunc_and_call
+
+
+@flag_dec
+def prompt(msg):
+    return raw_input(msg)
+
 
 def finish(exitcode=0):
     os.chdir(cwd)
@@ -24,7 +50,8 @@ if argc < 2:
     usage(1)
 
 
-root = subprocess.check_output('git rev-parse --show-toplevel', shell=True).strip()
+root = subprocess.check_output(
+    'git rev-parse --show-toplevel', shell=True).strip()
 
 os.chdir(root)
 
@@ -45,14 +72,21 @@ else:
         cwd_tmp = cwd_tmp[:last_slash]
         gitproj_tmpdir = cwd_tmp + '/.gitproj'
         if cwd_tmp.lower() == root.lower():
-            print('Hit the root of the project. Uses project root .gitproj file. Halt.')
+            print(
+                'Hit the root of the project. '
+                'Uses project root .gitproj file.')
             break
         if os.path.isfile(gitproj_tmpdir):
-            load_comfirm = raw_input('Found gitproj at ' + gitproj_tmpdir +
-                                      '\nAre you sure you want to use it(y/n)?')
+            load_comfirm = prompt(
+                'Found gitproj at ' + gitproj_tmpdir +
+                '\nAre you sure you want to use it(y/n)?'
+                )
             found_gitproj = False
             # make sure user gives either y/n
-            while ((load_comfirm != 'y' or load_comfirm != 'n') and not found_gitproj):
+            while (
+                load_comfirm != 'y' or load_comfirm != 'n'
+                ) \
+                    and not found_gitproj:
                 if load_comfirm.lower() == 'y':
                     root = cwd_tmp
                     os.chdir(root)
@@ -62,7 +96,8 @@ else:
                     print 'continue searching'
                     break
                 else:
-                    load_comfirm = raw_input(' invalid input ' + load_comfirm +
+                    load_comfirm = prompt(
+                        ' invalid input ' + load_comfirm +
                         '\n Are you sure you want to use ' + gitproj_tmpdir
                         + '(y/n)?')
             # break while loop after found gitproj


### PR DESCRIPTION
refer to: #36 

Make `.gitproj` work as `eslintrc`.  Find the closest `.gitproj` available and use that as `root` for gitjjproj

TODO:
- [x] if dir is not a git repo then halt (like how it was before)
- [x] look for parent dir `.gitproj`. Stop when hits the top level of repo. 
- [x] use current working directory `.gitproj` if there is one 
- [x] take user inputs to confirm the usage of found `.gitproj`, if hits the top-level of th repo, just use the top level one (project root)
- [x] wrap up raw_input into a flag
- [x] implement flag handler for function calls
- [ ] update tests (nosetests 🤔 )